### PR TITLE
Add expand_variable_patterns tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,36 @@
+/// Library for auto-hash utilities.
+
+/// Expand patterns with variable '?x' into sequences of '?1' repeated
+/// between `min` and `max` times. If the pattern doesn't contain `?x`,
+/// the original pattern is returned.
+pub fn expand_variable_patterns(base_pattern: &str, min: usize, max: usize) -> Vec<String> {
+    let mut patterns = Vec::new();
+    if base_pattern.contains("?x") {
+        for len in min..=max {
+            let replacement = "?1".repeat(len);
+            let pat = base_pattern.replace("?x", &replacement);
+            patterns.push(pat);
+        }
+    } else {
+        patterns.push(base_pattern.to_string());
+    }
+    patterns
+}
+
+#[cfg(test)]
+mod tests {
+    use super::expand_variable_patterns;
+
+    #[test]
+    fn test_expand_var() {
+        let result = expand_variable_patterns("ab?xcd", 1, 3);
+        assert_eq!(result, vec!["ab?1cd", "ab?1?1cd", "ab?1?1?1cd"]);
+    }
+
+    #[test]
+    fn test_without_placeholder() {
+        let result = expand_variable_patterns("abc", 1, 2);
+        assert_eq!(result, vec!["abc"]);
+    }
+}
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::fs::File;
 use std::io::{self, BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use auto_hash::expand_variable_patterns;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
@@ -59,19 +60,6 @@ fn main() -> io::Result<()> {
 }
 
 
-fn expand_variable_patterns(base_pattern: &str, min: usize, max: usize) -> Vec<String> {
-    let mut patterns = Vec::new();
-    if base_pattern.contains("?x") {
-        for len in min..=max {
-            let replacement = "?1".repeat(len);
-            let pat = base_pattern.replace("?x", &replacement);
-            patterns.push(pat);
-        }
-    } else {
-        patterns.push(base_pattern.to_string());
-    }
-    patterns
-}
 
 fn run_hashcat(
     file_path: &Path,

--- a/tests/patterns.rs
+++ b/tests/patterns.rs
@@ -1,0 +1,17 @@
+use auto_hash::expand_variable_patterns;
+
+#[test]
+fn expand_question_x_varies_with_min_max() {
+    let patterns = expand_variable_patterns("pre?xpost", 1, 3);
+    assert_eq!(patterns, vec![
+        "pre?1post",
+        "pre?1?1post",
+        "pre?1?1?1post",
+    ]);
+}
+
+#[test]
+fn returns_original_when_placeholder_absent() {
+    let patterns = expand_variable_patterns("no_placeholder", 2, 4);
+    assert_eq!(patterns, vec!["no_placeholder"]);
+}


### PR DESCRIPTION
## Summary
- expose `expand_variable_patterns` via new `lib.rs`
- update `main.rs` to use library function
- add integration tests in `tests/patterns.rs`

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_685e96b460708326a3cc1de97a0ad376