### PR TITLE
Add pattern file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# auto-hash
+
+Small CLI wrapper around hashcat. Allows specifying patterns either via command line or a file.
+
+## Usage
+
+```bash
+cargo run --release -- \ \
+  --input-file hashes.txt \
+  --output results.txt \
+  --alphabet abcdef \
+  --min 1 --max 3 \
+  --patterns ?d?d \
+  --t 0 
+```
+
+### Pattern file
+
+Patterns can also be provided through a file with `--pattern-file`. Each line of the file is treated as a pattern and appended to any patterns passed directly by `--patterns`.
+
+```bash
+cargo run --release -- --input-file hashes.txt --output results.txt \
+  --alphabet abcdef --min 1 --max 3 \
+  --pattern-file patterns.txt --t 0
+```

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,17 +27,32 @@ struct Args {
     patterns: Vec<String>,
 
     #[arg(long)]
+    pattern_file: Option<PathBuf>,
+
+    #[arg(long)]
     t: Vec<usize>
 }
 
 fn main() -> io::Result<()> {
     let args = Args::parse();
 
+    let mut patterns = args.patterns.clone();
+    if let Some(path) = args.pattern_file.as_ref() {
+        let file = File::open(path)?;
+        for line in BufReader::new(file).lines() {
+            if let Ok(pat) = line {
+                if !pat.trim().is_empty() {
+                    patterns.push(pat);
+                }
+            }
+        }
+    }
+
     println!("Archivo de salida de hashcat: {}", args.output.display());
-        
+
     println!("Procesando archivo");
 
-    for pattern in &args.patterns {
+    for pattern in &patterns {
         for hash_type in args.t.iter() {
             let expanded_patterns = expand_variable_patterns(pattern, args.min, args.max);
 


### PR DESCRIPTION
## Summary
- support reading patterns from file with `--pattern-file`
- document pattern file usage in README

## Testing
- `cargo check --offline` *(fails: no matching package named `tempfile` found)*
- `cargo check --locked --offline` *(fails: no matching package named `tempfile` found)*
- `rustup component add rustfmt` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_685e96b53e6c8326bb35d9d7c69833b3