### PR TITLE
Add configurable attack mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# Auto Hash
+
+Utility to automate Hashcat tasks from Rust.
+
+## Usage
+
+Run the binary with the desired options:
+
+```bash
+auto-hash \
+  --input-file <path> \
+  --output <result file> \
+  --min <length> \
+  --max <length> \
+  --alphabet <chars> \
+  --patterns <patterns>... \
+  --t <hash types>... \
+  [--attack-mode <mode>]
+```
+
+### Parameters
+
+- `--input-file` Path to the hashes to crack.
+- `--output` File where results are written.
+- `--min` Minimum length when expanding `?x` patterns.
+- `--max` Maximum length when expanding `?x` patterns.
+- `--alphabet` Characters used for the custom charset `?1`.
+- `--patterns` Wordlist of patterns to try. Use `?x` to expand based on `min` and `max`.
+- `--t` Hash types passed to Hashcat.
+- `--attack-mode` Hashcat attack mode (default: `3`).
+
+The program prints each attempt and displays the contents of the output file when finished.

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,10 @@ struct Args {
     patterns: Vec<String>,
 
     #[arg(long)]
-    t: Vec<usize>
+    t: Vec<usize>,
+
+    #[arg(long, default_value = "3")]
+    attack_mode: u8,
 }
 
 fn main() -> io::Result<()> {
@@ -43,7 +46,14 @@ fn main() -> io::Result<()> {
 
             for pat in expanded_patterns {
                 println!("Intentando: {} con : {}", pat, hash_type);
-                match run_hashcat(&args.input_file, &args.output, &args.alphabet, &pat, hash_type) {
+                match run_hashcat(
+                    &args.input_file,
+                    &args.output,
+                    &args.alphabet,
+                    &pat,
+                    hash_type,
+                    args.attack_mode,
+                ) {
                     Some(result) => println!("[{}]: {}", pat, result),
                     None => println!("[{}]: Error desconocido", pat),
                 }
@@ -79,12 +89,13 @@ fn run_hashcat(
     alphabet: &str,
     pattern: &str,
     hash_type: &usize,
+    attack_mode: u8,
 ) -> Option<String> {
     let hashcat_cmd = get_hashcat_command();
 
     let output_result = Command::new(hashcat_cmd)
         .arg("-a")
-        .arg("3")
+        .arg(attack_mode.to_string())
         .arg("-m")
         .arg(hash_type.to_string())
         .arg("-w")


### PR DESCRIPTION
## Summary
- add `attack_mode` parameter with default value `3`
- use `attack_mode` when running hashcat
- document usage in README

## Testing
- `cargo test --quiet` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_685e96b5a4f4832691b472b71dd8f687